### PR TITLE
Various api updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
         with:
           coverageCommand: npm test -- --ci --coverage
+          debug: true
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,41 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
+      - name: Checkout (pull_request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout (push)
+        if: github.event_name == 'push'
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: npm install
-      - run: npm test -- --ci
+      - run: npm test -- --ci --coverage
       - run: npm run lint
-      - uses: paambaati/codeclimate-action@v2.5.3
-        env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      - name: Set ENV for codeclimate (pull_request)
+        run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/$GITHUB_HEAD_REF:refs/remotes/origin/$GITHUB_HEAD_REF
+          echo "::set-env name=GIT_BRANCH::$GITHUB_HEAD_REF"
+          echo "::set-env name=GIT_COMMIT_SHA::$(git rev-parse origin/$GITHUB_HEAD_REF)"
+        if: github.event_name == 'pull_request'
+      - name: Set ENV for codeclimate (push)
+        run: |
+          echo "::set-env name=GIT_BRANCH::$GITHUB_REF"
+          echo "::set-env name=GIT_COMMIT_SHA::$GITHUB_SHA"
+        if: github.event_name == 'push'
+      - name: Code Climate Test Reporter
+        uses: aktions/codeclimate-test-reporter@v1
         with:
-          coverageCommand: npm test -- --ci --coverage
-          debug: true
+          codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/

--- a/src/api/constants.tsx
+++ b/src/api/constants.tsx
@@ -1,4 +1,4 @@
-import {ApiRequestFetchPolicy} from './typings'
+import {ApiRequestFetchPolicy, ApiRequestMethod} from './typings'
 
 /**
  * Fetch policies which will return the cached value (if exists)
@@ -10,3 +10,5 @@ export const READ_CACHE_POLICIES: ApiRequestFetchPolicy[] = [
 ]
 
 export const DEFAULT_FETCH_POLICY: ApiRequestFetchPolicy = 'no-cache'
+
+export const DEFAULT_REQUEST_METHOD: ApiRequestMethod = 'GET'

--- a/src/api/constants.tsx
+++ b/src/api/constants.tsx
@@ -9,6 +9,6 @@ export const READ_CACHE_POLICIES: ApiRequestFetchPolicy[] = [
   'cache-and-fetch'
 ]
 
-export const DEFAULT_FETCH_POLICY: ApiRequestFetchPolicy = 'no-cache'
+export const DEFAULT_FETCH_POLICY: ApiRequestFetchPolicy = 'fetch-first'
 
 export const DEFAULT_REQUEST_METHOD: ApiRequestMethod = 'GET'

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -30,6 +30,18 @@ it('applies the base URL to requests', async () => {
   expect(request.url).toEqual('http://test.com/endpoint')
 })
 
+describe('defaultFetchPolicy', () => {
+  it('defaults to fetch-first', () => {
+    expect(new Api().defaultFetchPolicy).toEqual('fetch-first')
+  })
+
+  it('can be overridden', () => {
+    expect(
+      new Api({defaultFetchPolicy: 'no-cache'}).defaultFetchPolicy
+    ).toEqual('no-cache')
+  })
+})
+
 describe('request headers', () => {
   it('applies default headers', async () => {
     fetchMock.mockResponseOnce(JSON.stringify({num: 12345}), {

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -2,7 +2,7 @@ import 'jest-fetch-mock'
 
 import {Api} from './'
 import {ApiCacheMissError, ApiError} from './errors'
-import {ApiRequestMethod, IApiRequestParams} from './typings'
+import {ApiRequestMethod, ApiRequestParams} from './typings'
 
 const BASE_URL = 'http://test.com'
 let api: Api
@@ -188,7 +188,7 @@ describe('fetch policies', () => {
       headers: {'content-type': 'application/json'}
     })
 
-    const params: IApiRequestParams<'GET', {}> = {
+    const params: ApiRequestParams<'GET', {}> = {
       method: 'GET',
       url: '/endpoint'
     }
@@ -253,7 +253,7 @@ describe('fetch policies', () => {
       headers: {'content-type': 'application/json'}
     })
 
-    const params: IApiRequestParams<'GET', {}> = {
+    const params: ApiRequestParams<'GET', {}> = {
       method: 'GET',
       url: '/endpoint'
     }
@@ -290,7 +290,7 @@ describe('deduplication', () => {
       headers: {'content-type': 'application/json'}
     })
 
-    const params: IApiRequestParams<'GET', {}> = {
+    const params: ApiRequestParams<'GET', {}> = {
       method: 'GET',
       url: '/endpoint'
     }
@@ -309,7 +309,7 @@ describe('deduplication', () => {
       headers: {'content-type': 'application/json'}
     })
 
-    const params: IApiRequestParams<'GET', {}> = {
+    const params: ApiRequestParams<'GET', {}> = {
       method: 'GET',
       url: '/endpoint'
     }
@@ -330,7 +330,7 @@ describe('deduplication', () => {
       headers: {'content-type': 'application/json'}
     })
 
-    const params: IApiRequestParams<'GET', {}> = {
+    const params: ApiRequestParams<'GET', {}> = {
       method: 'GET',
       url: '/endpoint'
     }
@@ -349,7 +349,7 @@ describe('deduplication', () => {
       headers: {'content-type': 'application/json'}
     })
 
-    const params: IApiRequestParams<'GET', {}> = {
+    const params: ApiRequestParams<'GET', {}> = {
       method: 'GET',
       url: '/endpoint'
     }
@@ -369,7 +369,7 @@ describe('deduplication', () => {
         headers: {'content-type': 'application/json'}
       })
 
-      const params: IApiRequestParams = {
+      const params: ApiRequestParams = {
         method: 'GET',
         url: '/endpoint'
       }
@@ -385,7 +385,7 @@ describe('deduplication', () => {
         headers: {'content-type': 'application/json'}
       })
 
-      const params: IApiRequestParams = {
+      const params: ApiRequestParams = {
         method: 'GET',
         url: '/endpoint'
       }
@@ -410,7 +410,7 @@ describe('deduplication', () => {
           headers: {'content-type': 'application/json'}
         })
 
-        const params: IApiRequestParams = {
+        const params: ApiRequestParams = {
           method,
           url: '/endpoint'
         }
@@ -429,7 +429,7 @@ describe('deduplication', () => {
           headers: {'content-type': 'application/json'}
         })
 
-        const params: IApiRequestParams = {
+        const params: ApiRequestParams = {
           method,
           url: '/endpoint'
         }
@@ -446,7 +446,7 @@ describe('deduplication', () => {
 })
 
 test('manual cache read/write and listener', async () => {
-  const params: IApiRequestParams<'GET', {}> = {
+  const params: ApiRequestParams<'GET', {}> = {
     method: 'GET',
     url: '/endpoint'
   }

--- a/src/api/index.spec.tsx
+++ b/src/api/index.spec.tsx
@@ -12,11 +12,11 @@ beforeEach(() => {
   fetchMock.mockClear()
 })
 
-it('does not require a base URL', async () => {
+it('does not require a base URL or method to make a GET request', async () => {
   fetchMock.mockResponseOnce(JSON.stringify({num: 12345}), {
     headers: {'content-type': 'application/json'}
   })
-  await new Api().request({method: 'GET', url: 'http://some_site.com/endpoint'})
+  await new Api().request({url: 'http://some_site.com/endpoint'})
   const request = fetchMock.mock.calls[0][0] as Request
   expect(request.url).toEqual('http://some_site.com/endpoint')
 })

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -6,6 +6,7 @@ import {GenericCache} from './generic-cache'
 import {createSubscription, genCacheUpdateEvent, getParamsId} from './lib'
 import {ApiRequestManager} from './request-manager'
 import {
+  ApiRequestFetchPolicy,
   ApiRequestMethod,
   ApiRequestOptions,
   IApiParseResponseJson,
@@ -17,7 +18,7 @@ import {
 const ERROR_EVENT = 'error'
 
 export class Api {
-  defaultFetchPolicy = DEFAULT_FETCH_POLICY
+  defaultFetchPolicy: ApiRequestFetchPolicy
 
   private responseBodyCache = new GenericCache<ResponseBody>()
 
@@ -32,6 +33,13 @@ export class Api {
        */
       baseUrl?: string
       /**
+       * When set, overrides the fetch policy for all requests.
+       *
+       * Note that this differs from the `useApiQuery` default fetch policy,
+       * which can be configured using `ApiProvider`.
+       */
+      defaultFetchPolicy?: ApiRequestFetchPolicy
+      /**
        * When provided, all API JSON request bodies will be run
        * through this transformation function before the API request
        */
@@ -44,6 +52,7 @@ export class Api {
     } = {}
   ) {
     this.requestManager = new ApiRequestManager(params)
+    this.defaultFetchPolicy = params.defaultFetchPolicy || DEFAULT_FETCH_POLICY
     this.requestManager.onReceivedResponseBody(this.writeCachedResponse)
     this.requestManager.onError((error) =>
       this.emitter.emit(ERROR_EVENT, error)

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,6 +1,10 @@
 import EventEmitter from 'eventemitter3'
 
-import {DEFAULT_FETCH_POLICY, READ_CACHE_POLICIES} from './constants'
+import {
+  DEFAULT_FETCH_POLICY,
+  DEFAULT_REQUEST_METHOD,
+  READ_CACHE_POLICIES
+} from './constants'
 import {ApiCacheMissError} from './errors'
 import {GenericCache} from './generic-cache'
 import {createSubscription, genCacheUpdateEvent, getParamsId} from './lib'
@@ -57,9 +61,10 @@ export class Api {
     params: IApiRequestParams<ApiRequestMethod, TResponseBody>,
     options: ApiRequestOptions = {}
   ): Promise<TResponseBody> => {
+    const {method = DEFAULT_REQUEST_METHOD} = params
     const {fetchPolicy = DEFAULT_FETCH_POLICY} = options
 
-    if (params.method !== 'GET' || !READ_CACHE_POLICIES.includes(fetchPolicy)) {
+    if (method !== 'GET' || !READ_CACHE_POLICIES.includes(fetchPolicy)) {
       return this.requestManager.getResponseBody<TResponseBody>(
         params,
         options

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -6,12 +6,12 @@ import {GenericCache} from './generic-cache'
 import {createSubscription, genCacheUpdateEvent, getParamsId} from './lib'
 import {ApiRequestManager} from './request-manager'
 import {
+  ApiParseResponseJson,
   ApiRequestFetchPolicy,
   ApiRequestMethod,
   ApiRequestOptions,
-  IApiParseResponseJson,
-  IApiRequestParams,
-  IApiSerializeRequestJson,
+  ApiRequestParams,
+  ApiSerializeRequestJson,
   ResponseBody
 } from './typings'
 
@@ -43,12 +43,12 @@ export class Api {
        * When provided, all API JSON request bodies will be run
        * through this transformation function before the API request
        */
-      serializeRequestJson?: IApiSerializeRequestJson
+      serializeRequestJson?: ApiSerializeRequestJson
       /**
        * When provided, all API JSON response bodies will be run
        * through this transformation function before returning the response
        */
-      parseResponseJson?: IApiParseResponseJson
+      parseResponseJson?: ApiParseResponseJson
     } = {}
   ) {
     this.requestManager = new ApiRequestManager(params)
@@ -63,7 +63,7 @@ export class Api {
    * Makes an API request
    */
   request = <TResponseBody extends ResponseBody>(
-    params: IApiRequestParams<ApiRequestMethod, TResponseBody>,
+    params: ApiRequestParams<ApiRequestMethod, TResponseBody>,
     options: ApiRequestOptions = {}
   ): Promise<TResponseBody> => {
     const {fetchPolicy = DEFAULT_FETCH_POLICY} = options
@@ -102,7 +102,7 @@ export class Api {
   /**
    * Returns `true` if a `GET` of `DELETE` request matches params
    */
-  requestInProgress = (params: IApiRequestParams): boolean => {
+  requestInProgress = (params: ApiRequestParams): boolean => {
     return this.requestManager.requestInProgress(params)
   }
 
@@ -110,7 +110,7 @@ export class Api {
    * Saves a response directly to the cache
    */
   writeCachedResponse = <TResponseBody extends ResponseBody>(
-    params: IApiRequestParams<ApiRequestMethod, TResponseBody>,
+    params: ApiRequestParams<ApiRequestMethod, TResponseBody>,
     responseBody: TResponseBody
   ) => {
     this.responseBodyCache.set(getParamsId(params), responseBody)
@@ -126,7 +126,7 @@ export class Api {
    * Note that if there is a cache miss, it will return `undefined`
    */
   readCachedResponse = <TResponseBody extends ResponseBody>(
-    params: IApiRequestParams<ApiRequestMethod, TResponseBody>
+    params: ApiRequestParams<ApiRequestMethod, TResponseBody>
   ): TResponseBody => {
     return this.responseBodyCache.get(getParamsId(params)) as TResponseBody
   }
@@ -135,7 +135,7 @@ export class Api {
    * Subscribes to cache updates for a given param's response
    */
   onCacheUpdate = <TResponseBody extends ResponseBody>(
-    params: IApiRequestParams<ApiRequestMethod, TResponseBody>,
+    params: ApiRequestParams<ApiRequestMethod, TResponseBody>,
     listener: (responseBody: TResponseBody) => void
   ): (() => void) => {
     const event = genCacheUpdateEvent(params)

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,10 +1,6 @@
 import EventEmitter from 'eventemitter3'
 
-import {
-  DEFAULT_FETCH_POLICY,
-  DEFAULT_REQUEST_METHOD,
-  READ_CACHE_POLICIES
-} from './constants'
+import {DEFAULT_FETCH_POLICY, READ_CACHE_POLICIES} from './constants'
 import {ApiCacheMissError} from './errors'
 import {GenericCache} from './generic-cache'
 import {createSubscription, genCacheUpdateEvent, getParamsId} from './lib'
@@ -61,10 +57,9 @@ export class Api {
     params: IApiRequestParams<ApiRequestMethod, TResponseBody>,
     options: ApiRequestOptions = {}
   ): Promise<TResponseBody> => {
-    const {method = DEFAULT_REQUEST_METHOD} = params
     const {fetchPolicy = DEFAULT_FETCH_POLICY} = options
 
-    if (method !== 'GET' || !READ_CACHE_POLICIES.includes(fetchPolicy)) {
+    if (!READ_CACHE_POLICIES.includes(fetchPolicy)) {
       return this.requestManager.getResponseBody<TResponseBody>(
         params,
         options

--- a/src/api/lib.spec.tsx
+++ b/src/api/lib.spec.tsx
@@ -129,6 +129,43 @@ describe('getParamsId', () => {
       })
     )
   })
+
+  it('serializes an extra key', () => {
+    const requestParams: IApiRequestParams = {
+      method: 'GET',
+      url: '/endpoint'
+    }
+
+    for (const extraKey of [null, undefined]) {
+      expect(getParamsId(requestParams)).toEqual(
+        getParamsId({
+          ...requestParams,
+          extraKey
+        })
+      )
+    }
+
+    expect(
+      getParamsId({
+        ...requestParams,
+        extraKey: 'test'
+      })
+    ).toEqual(
+      getParamsId({
+        ...requestParams,
+        extraKey: 'test'
+      })
+    )
+
+    for (const extraKey of ['', 'one']) {
+      expect(getParamsId(requestParams)).not.toEqual(
+        getParamsId({
+          ...requestParams,
+          extraKey
+        })
+      )
+    }
+  })
 })
 
 test('applyHeaders', () => {

--- a/src/api/lib.spec.tsx
+++ b/src/api/lib.spec.tsx
@@ -1,9 +1,9 @@
 import {applyHeaders, getParamsId} from './lib'
-import {IApiRequestParams} from './typings'
+import {ApiRequestParams} from './typings'
 
 describe('getParamsId', () => {
   it('serializes basic requests', () => {
-    const requestParams: IApiRequestParams = {
+    const requestParams: ApiRequestParams = {
       method: 'GET',
       url: '/endpoint'
     }
@@ -30,7 +30,7 @@ describe('getParamsId', () => {
   })
 
   it('serializes headers', () => {
-    const requestParams: IApiRequestParams = {
+    const requestParams: ApiRequestParams = {
       method: 'GET',
       url: '/endpoint'
     }
@@ -98,7 +98,7 @@ describe('getParamsId', () => {
   })
 
   it('serializes response type', () => {
-    const requestParams: IApiRequestParams = {
+    const requestParams: ApiRequestParams = {
       method: 'GET',
       url: '/endpoint',
       responseType: null
@@ -137,7 +137,7 @@ describe('getParamsId', () => {
   })
 
   it('serializes an extra key', () => {
-    const requestParams: IApiRequestParams = {
+    const requestParams: ApiRequestParams = {
       method: 'GET',
       url: '/endpoint'
     }

--- a/src/api/lib.spec.tsx
+++ b/src/api/lib.spec.tsx
@@ -8,6 +8,12 @@ describe('getParamsId', () => {
       url: '/endpoint'
     }
 
+    expect(getParamsId(requestParams)).toEqual(
+      getParamsId({
+        url: '/endpoint' // method defaults to GET
+      })
+    )
+
     expect(getParamsId(requestParams)).not.toEqual(
       getParamsId({
         ...requestParams,

--- a/src/api/lib.tsx
+++ b/src/api/lib.tsx
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3'
 
+import {DEFAULT_REQUEST_METHOD} from './constants'
 import {ApiHeaders, ApiRequestMethod, IApiRequestParams} from './typings'
 
 /**
@@ -11,7 +12,7 @@ export function getParamsId(
   params: IApiRequestParams<ApiRequestMethod>
 ): string {
   return JSON.stringify([
-    params.method,
+    params.method || DEFAULT_REQUEST_METHOD,
     params.url,
     params.responseType || '',
     serializeHeaders(params.headers),

--- a/src/api/lib.tsx
+++ b/src/api/lib.tsx
@@ -1,7 +1,7 @@
 import EventEmitter from 'eventemitter3'
 
 import {DEFAULT_REQUEST_METHOD} from './constants'
-import {ApiHeaders, ApiRequestMethod, IApiRequestParams} from './typings'
+import {ApiHeaders, ApiRequestMethod, ApiRequestParams} from './typings'
 
 /**
  * Returns an id represent the request parameters.
@@ -9,7 +9,7 @@ import {ApiHeaders, ApiRequestMethod, IApiRequestParams} from './typings'
  * This is used to identify the request for caching and other purposes.
  */
 export function getParamsId(
-  params: IApiRequestParams<ApiRequestMethod>
+  params: ApiRequestParams<ApiRequestMethod>
 ): string {
   return JSON.stringify([
     params.method || DEFAULT_REQUEST_METHOD,
@@ -53,7 +53,7 @@ export function applyHeaders(prevHeaders: Headers, apiHeaders: ApiHeaders) {
 }
 
 export function genCacheUpdateEvent(
-  params: IApiRequestParams<ApiRequestMethod>
+  params: ApiRequestParams<ApiRequestMethod>
 ) {
   return `cacheUpdate.${getParamsId(params)}`
 }

--- a/src/api/lib.tsx
+++ b/src/api/lib.tsx
@@ -14,7 +14,8 @@ export function getParamsId(
     params.method,
     params.url,
     params.responseType || '',
-    serializeHeaders(params.headers)
+    serializeHeaders(params.headers),
+    params.extraKey
   ])
 }
 

--- a/src/api/request-manager/index.spec.tsx
+++ b/src/api/request-manager/index.spec.tsx
@@ -1,4 +1,4 @@
-import {IApiRequestParams, RequestFetcher} from '../typings'
+import {ApiRequestParams, RequestFetcher} from '../typings'
 import {ApiRequestManager} from './'
 
 const requestFetcher: RequestFetcher = {
@@ -20,7 +20,7 @@ it('does not cache the response if not the most recent request for the params', 
   })
   ;(requestFetcher.getResponse as jest.Mock).mockReturnValueOnce(request2)
 
-  const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+  const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
   const getResponseBody1 = requestManager.getResponseBody(params, {
     deduplicate: false
   })

--- a/src/api/request-manager/index.spec.tsx
+++ b/src/api/request-manager/index.spec.tsx
@@ -22,10 +22,10 @@ it('does not cache the response if not the most recent request for the params', 
 
   const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
   const getResponseBody1 = requestManager.getResponseBody(params, {
-    forceNewFetch: true
+    deduplicate: false
   })
   const getResponseBody2 = requestManager.getResponseBody(params, {
-    forceNewFetch: true
+    deduplicate: false
   })
 
   // resolve first request before second request finishes

--- a/src/api/request-manager/index.tsx
+++ b/src/api/request-manager/index.tsx
@@ -6,11 +6,11 @@ import {GenericCache} from '../generic-cache'
 import {applyHeaders, createSubscription, getParamsId} from '../lib'
 import {ApiRequestFetcher} from '../request-fetcher'
 import {
+  ApiParseResponseJson,
   ApiRequestMethod,
   ApiRequestOptions,
-  IApiParseResponseJson,
-  IApiRequestParams,
-  IApiSerializeRequestJson,
+  ApiRequestParams,
+  ApiSerializeRequestJson,
   RequestBody,
   RequestFetcher,
   ResponseBody
@@ -40,9 +40,9 @@ export class ApiRequestManager {
 
   private requestFetcher: RequestFetcher
 
-  private serializeRequestJson: IApiSerializeRequestJson
+  private serializeRequestJson: ApiSerializeRequestJson
 
-  private parseResponseJson: IApiParseResponseJson
+  private parseResponseJson: ApiParseResponseJson
 
   private defaultHeaders = new Headers()
 
@@ -60,12 +60,12 @@ export class ApiRequestManager {
      * When provided, all API JSON request bodies will be run
      * through this transformation function before the API request
      */
-    serializeRequestJson?: IApiSerializeRequestJson
+    serializeRequestJson?: ApiSerializeRequestJson
     /**
      * When provided, all API JSON response bodies will be run
      * through this transformation function before returning the response
      */
-    parseResponseJson?: IApiParseResponseJson
+    parseResponseJson?: ApiParseResponseJson
     requestFetcher?: RequestFetcher
   }) {
     this.baseUrl = params.baseUrl || ''
@@ -83,7 +83,7 @@ export class ApiRequestManager {
    * On a successful fetch, it will cache the response unless `fetchPolicy` is `'no-cache'`
    */
   getResponseBody = <TResponseBody extends ResponseBody>(
-    params: IApiRequestParams<ApiRequestMethod, TResponseBody>,
+    params: ApiRequestParams<ApiRequestMethod, TResponseBody>,
     options: ApiRequestOptions
   ): Promise<TResponseBody | null> => {
     const paramsKey = getParamsId(params)
@@ -109,7 +109,7 @@ export class ApiRequestManager {
   }
 
   private async createRequestPromise(
-    params: IApiRequestParams,
+    params: ApiRequestParams,
     options: ApiRequestOptions,
     id: symbol
   ): Promise<ResponseBody | null> {
@@ -130,7 +130,7 @@ export class ApiRequestManager {
    * Configuring an error handler to be called on error
    */
   onReceivedResponseBody = (
-    listener: (params: IApiRequestParams, responseBody: ResponseBody) => void
+    listener: (params: ApiRequestParams, responseBody: ResponseBody) => void
   ) => {
     return createSubscription(
       this.emitter,
@@ -149,7 +149,7 @@ export class ApiRequestManager {
   /**
    * Returns `true` if a `GET` request matches params
    */
-  requestInProgress = (params: IApiRequestParams): boolean => {
+  requestInProgress = (params: ApiRequestParams): boolean => {
     return this.inProgressRequestCache.has(getParamsId(params))
   }
 
@@ -165,7 +165,7 @@ export class ApiRequestManager {
   }
 
   private fetchResponseBody = async (
-    params: IApiRequestParams,
+    params: ApiRequestParams,
     options: ApiRequestOptions
   ): Promise<ResponseBody | null> => {
     const {method = DEFAULT_REQUEST_METHOD} = params
@@ -227,6 +227,6 @@ export class ApiRequestManager {
   }
 }
 
-function defaultDeduplicate(params: IApiRequestParams) {
+function defaultDeduplicate(params: ApiRequestParams) {
   return params.method === 'GET' ? true : false
 }

--- a/src/api/request-manager/index.tsx
+++ b/src/api/request-manager/index.tsx
@@ -1,6 +1,6 @@
 import EventEmitter from 'eventemitter3'
 
-import {DEFAULT_FETCH_POLICY} from '../constants'
+import {DEFAULT_FETCH_POLICY, DEFAULT_REQUEST_METHOD} from '../constants'
 import {ApiError} from '../errors'
 import {GenericCache} from '../generic-cache'
 import {applyHeaders, createSubscription, getParamsId} from '../lib'
@@ -168,6 +168,7 @@ export class ApiRequestManager {
     params: IApiRequestParams,
     options: ApiRequestOptions
   ): Promise<ResponseBody | null> => {
+    const {method = DEFAULT_REQUEST_METHOD} = params
     const {fetchPolicy = DEFAULT_FETCH_POLICY} = options
     try {
       let headers = new Headers(this.defaultHeaders)
@@ -178,7 +179,7 @@ export class ApiRequestManager {
 
       let body: BodyInit | undefined
 
-      if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(params.method)) {
+      if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
         const paramBody = (params as {body: RequestBody}).body
 
         if (
@@ -197,7 +198,7 @@ export class ApiRequestManager {
       }
 
       const response = await this.requestFetcher.getResponse({
-        method: params.method,
+        method,
         url: `${this.baseUrl}${params.url}`,
         body,
         headers,

--- a/src/api/typings.tsx
+++ b/src/api/typings.tsx
@@ -11,7 +11,7 @@ export type ApiResponseType = 'json' | 'text' | 'blob'
 
 interface ApiCommonRequestParams<TMethod extends ApiRequestMethod> {
   url: string
-  method: TMethod
+  method?: TMethod
   headers?: ApiHeaders
   responseType?: ApiResponseType
   extraKey?: string

--- a/src/api/typings.tsx
+++ b/src/api/typings.tsx
@@ -29,7 +29,7 @@ export interface ApiMutationRequestParams<
   body?: RequestBody
 }
 
-export type IApiRequestParams<
+export type ApiRequestParams<
   TMethod extends ApiRequestMethod = ApiRequestMethod,
   TResponseBody extends ResponseBody = ResponseBody
 > = TMethod extends GetDeleteRequestMethod
@@ -38,9 +38,9 @@ export type IApiRequestParams<
   ? ApiMutationRequestParams<TMethod, TResponseBody>
   : never
 
-export type IApiSerializeRequestJson = (body: object) => object
+export type ApiSerializeRequestJson = (body: object) => object
 
-export type IApiParseResponseJson = (body: object) => object
+export type ApiParseResponseJson = (body: object) => object
 
 export type ApiRequestFetchPolicy =
   /**

--- a/src/api/typings.tsx
+++ b/src/api/typings.tsx
@@ -14,6 +14,7 @@ interface ApiCommonRequestParams<TMethod extends ApiRequestMethod> {
   method: TMethod
   headers?: ApiHeaders
   responseType?: ApiResponseType
+  extraKey?: string
 }
 
 export interface ApiGetDeleteRequestParams<

--- a/src/api/typings.tsx
+++ b/src/api/typings.tsx
@@ -77,13 +77,13 @@ export interface ApiRequestOptions {
   fetchPolicy?: ApiRequestFetchPolicy
 
   /**
-   * Normally, identical concurrent `GET` requests will
-   * not retrigger a refetch, and will return the same promise.
+   * When `true`, will ensure that it reuses any duplicate
+   * requests that are currently occurring to cut down on requests.
    *
-   * When `forceNewFetch` is set to `true`, it will trigger
-   * a new request even if one is already occurring.
+   * This is `true` by default for `GET` requests, and `false` for
+   * non-`GET` requests, but you can override here on a per-request basis.
    */
-  forceNewFetch?: boolean
+  deduplicate?: boolean
 }
 
 export interface RequestFetcherParams {

--- a/src/endpoints/index.spec.tsx
+++ b/src/endpoints/index.spec.tsx
@@ -63,21 +63,42 @@ describe('HttpEndpoints', () => {
     }
   })
 
-  describe('query', () => {
-    test('default query serialization', () => {
-      const query = {
-        str: 'string',
-        num: 3,
-        undefined,
-        null: null,
-        empty: '',
-        zero: 0
-      }
+  test('default query serialization', () => {
+    const query = {
+      str: 'string',
+      num: 3,
+      undefined,
+      null: null,
+      empty: '',
+      zero: 0
+    }
+
+    for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
+      expect(Endpoints[method]({query})).toEqual({
+        method,
+        url: '/base/endpoint?empty=&null=null&num=3&str=string&zero=0'
+      })
+    }
+  })
+
+  test('extra key', () => {
+    for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
+      expect(Endpoints[method]({extraKey: 'test'})).toEqual({
+        method,
+        url: '/base/endpoint',
+        extraKey: 'test'
+      })
+    }
+  })
+
+  describe('trailing slash', () => {
+    test('applying trailing slash to each url', () => {
+      ;(Endpoints as any).trailingSlash = true
 
       for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']) {
-        expect(Endpoints[method]({query})).toEqual({
+        expect(Endpoints[method]()).toEqual({
           method,
-          url: '/base/endpoint?empty=&null=null&num=3&str=string&zero=0'
+          url: '/base/endpoint/'
         })
       }
     })

--- a/src/endpoints/index.tsx
+++ b/src/endpoints/index.tsx
@@ -3,7 +3,7 @@
 import {
   ApiHeaders,
   ApiRequestMethod,
-  IApiRequestParams,
+  ApiRequestParams,
   RequestBody,
   ResponseBody
 } from '../api/typings'
@@ -154,7 +154,7 @@ export class HttpEndpoints {
     method: TMethod,
     path: string,
     requestInit: EndpointCreateRequestInit = {}
-  ): IApiRequestParams<TMethod, TResponseBody> {
+  ): ApiRequestParams<TMethod, TResponseBody> {
     let url = this.buildPath(path)
 
     if (requestInit.query) {
@@ -167,7 +167,7 @@ export class HttpEndpoints {
       headers: requestInit.headers,
       body: requestInit.body,
       extraKey: requestInit.extraKey
-    } as IApiRequestParams<TMethod, TResponseBody>
+    } as ApiRequestParams<TMethod, TResponseBody>
   }
 }
 

--- a/src/endpoints/index.tsx
+++ b/src/endpoints/index.tsx
@@ -14,6 +14,7 @@ export interface EndpointCreateRequestInit {
   query?: ApiQueryParams
   headers?: ApiHeaders
   body?: RequestBody
+  extraKey?: string
 }
 
 export type ApiParam = string | number
@@ -164,7 +165,8 @@ export class HttpEndpoints {
       method,
       url,
       headers: requestInit.headers,
-      body: requestInit.body
+      body: requestInit.body,
+      extraKey: requestInit.extraKey
     } as IApiRequestParams<TMethod, TResponseBody>
   }
 }

--- a/src/react/context.tsx
+++ b/src/react/context.tsx
@@ -1,18 +1,43 @@
 import React, {createContext} from 'react'
 
 import {Api} from '../api'
+import {ApiRequestFetchPolicy} from '../api/typings'
 
-export const ApiContext = createContext<Api>(new Api())
+const DEFAULT_FETCH_POLICY = 'cache-and-fetch'
+
+interface ApiContext {
+  api: Api
+  defaultFetchPolicy: ApiRequestFetchPolicy
+}
+
+export const ApiContext = createContext<ApiContext>({
+  api: new Api(),
+  defaultFetchPolicy: DEFAULT_FETCH_POLICY
+})
 
 export interface ApiProviderProps {
+  /**
+   * The API instance to use
+   */
   api: Api
+
+  /**
+   * Sets the default `fetchPolicy` which is used by `useApiQuery`
+   * if no `fetchPolicy` is provided to the hook.
+   */
+  defaultFetchPolicy?: ApiRequestFetchPolicy
 }
 
 export const ApiProvider: React.FC<ApiProviderProps> = function ApiProvider(
   props
 ) {
   return (
-    <ApiContext.Provider value={props.api}>
+    <ApiContext.Provider
+      value={{
+        api: props.api,
+        defaultFetchPolicy: props.defaultFetchPolicy || DEFAULT_FETCH_POLICY
+      }}
+    >
       {props.children}
     </ApiContext.Provider>
   )

--- a/src/react/use-api-query/index.spec.tsx
+++ b/src/react/use-api-query/index.spec.tsx
@@ -5,7 +5,7 @@ import {act, renderHook} from '@testing-library/react-hooks'
 
 import {Api} from '../../api'
 import {ApiError} from '../../api/errors'
-import {ApiRequestFetchPolicy, IApiRequestParams} from '../../api/typings'
+import {ApiRequestFetchPolicy, ApiRequestParams} from '../../api/typings'
 import {ApiProvider} from '../context'
 import {useApiQuery} from './'
 
@@ -160,7 +160,7 @@ it('can disable reinitialization of data between successive requests', async () 
 
 describe('cache', () => {
   it('defaults fetchPolicy to cache-and-fetch', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
     const {waitForNextUpdate} = renderHook(() => useApiQuery(params), {
       wrapper
     })
@@ -174,7 +174,7 @@ describe('cache', () => {
   })
 
   it('uses defaultFetchPolicy from context', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
     const defaultFetchPolicy = 'no-cache'
     const {waitForNextUpdate} = renderHook(() => useApiQuery(params), {
       wrapper: function Wrapper({children}) {
@@ -195,7 +195,7 @@ describe('cache', () => {
   })
 
   it('initializes the data to null if there is no cached value for a cache-first policy', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
     const response = {name: 'Test'}
     const cacheFirstPolicies: ApiRequestFetchPolicy[] = [
       'cache-first',
@@ -236,7 +236,7 @@ describe('cache', () => {
   })
 
   it('initializes data to the cached value if its a cache-first policy', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
     const response = {name: 'Test'}
     const cacheFirstPolicies: ApiRequestFetchPolicy[] = [
       'cache-first',
@@ -277,7 +277,7 @@ describe('cache', () => {
   })
 
   it('does not initialize to the cached value if its a fetch-first policy', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
     const response = {name: 'Test'}
     const fetchFirstPolicies: ApiRequestFetchPolicy[] = [
       'no-cache',
@@ -310,7 +310,7 @@ describe('cache', () => {
   })
 
   it('updates data on to api cache updates', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
     const response = {name: 'Test'}
 
     const fetchPolicies: ApiRequestFetchPolicy[] = [
@@ -372,7 +372,7 @@ describe('cache', () => {
 
 describe('refetch', () => {
   it('refetches data', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
     const fetchPolicies: ApiRequestFetchPolicy[] = [
       null,
       'cache-first',
@@ -431,7 +431,7 @@ describe('refetch', () => {
   })
 
   it('can override deduplicate', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
 
     const response1 = {name: 'Test'}
     ;(api.request as jest.Mock).mockResolvedValue(response1)
@@ -571,7 +571,7 @@ describe('setData', () => {
   })
 
   it('writes to the cache if fetchPolicy is not no-cache', async () => {
-    const params: IApiRequestParams = {method: 'GET', url: '/endpoint'}
+    const params: ApiRequestParams = {method: 'GET', url: '/endpoint'}
     const response = {name: 'Test'}
     ;(api.request as jest.Mock).mockResolvedValue(response)
     const fetchPolicies: ApiRequestFetchPolicy[] = [

--- a/src/react/use-api-query/index.tsx
+++ b/src/react/use-api-query/index.tsx
@@ -62,15 +62,6 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
     forceNewFetch?: boolean
 
     /**
-     * Similar to the dependencies array that is passed to `useEffect`, `useMemo`, and `useCallback`.
-     *
-     * This is specifically helpful for example when you want to retrigger a `POST` request
-     * when parameters in the request body change, since `body` changes do not trigger
-     * a new fetch.
-     */
-    refetchOn?: any[]
-
-    /**
      * If true, will keep `data` from previous requests
      * until new data is received.
      */
@@ -151,7 +142,7 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
     return () => {
       unsubscribe()
     }
-  }, [paramsId, ...(opts.refetchOn || [])])
+  }, [paramsId])
 
   // return loading flag if `useEffect` hasn't kicked in yet
   // but the a new request is about to kick off

--- a/src/react/use-api-query/index.tsx
+++ b/src/react/use-api-query/index.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useReducer, useRef} from 'react'
+import {useContext, useEffect, useMemo, useReducer, useRef} from 'react'
 
 import {READ_CACHE_POLICIES} from '../../api/constants'
 import {getParamsId} from '../../api/lib'
@@ -8,7 +8,7 @@ import {
   IApiRequestParams,
   ResponseBody
 } from '../../api/typings'
-import {useApi} from '../use-api'
+import {ApiContext} from '../context'
 import {useApiQueryActions} from './actions'
 import {useApiQueryReducer} from './reducer'
 
@@ -69,8 +69,8 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
     dontReinitialize?: boolean
   } = {}
 ): [UseApiQueryData<TResponseBody>, UseApiQueryActions<TResponseBody>] {
-  const api = useApi()
-  const fetchPolicy = opts.fetchPolicy || api.defaultFetchPolicy
+  const {api, defaultFetchPolicy} = useContext(ApiContext)
+  const fetchPolicy = opts.fetchPolicy || defaultFetchPolicy
   const paramsId = params && getParamsId(params)
   const [state, dispatch] = useReducer(useApiQueryReducer, null, () => ({
     id: null,

--- a/src/react/use-api-query/index.tsx
+++ b/src/react/use-api-query/index.tsx
@@ -45,9 +45,10 @@ export interface UseApiQueryActions<TResponseBody extends ResponseBody> {
      * Passed as an option to `api.request` and guarantees that a
      * new request will be made.
      *
-     * By default, it will use `forceNewFetch` from the hook's options (`false` by default).
+     * By default, it will use `deduplicate` from the hook's options
+     * (`true` for `GET` requests, `false` for non-`GET` requests).
      */
-    forceNewFetch?: boolean
+    deduplicate?: boolean
   }) => void
 }
 
@@ -59,7 +60,7 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
   params: IApiRequestParams<ApiRequestMethod, TResponseBody> | null,
   opts: {
     fetchPolicy?: ApiRequestFetchPolicy
-    forceNewFetch?: boolean
+    deduplicate?: boolean
 
     /**
      * If true, will keep `data` from previous requests
@@ -119,7 +120,7 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
       try {
         const data = await api.request(params, {
           fetchPolicy,
-          forceNewFetch: opts.forceNewFetch
+          deduplicate: opts.deduplicate
         })
         dispatch(
           useApiQueryActions.success({
@@ -189,7 +190,7 @@ export function useApiQuery<TResponseBody extends ResponseBody>(
           const data = await api.request(params, {
             fetchPolicy:
               fetchPolicy === 'no-cache' ? 'no-cache' : 'fetch-first',
-            forceNewFetch: opts.forceNewFetch || refetchOpts.forceNewFetch
+            deduplicate: refetchOpts.deduplicate ?? opts.deduplicate
           })
           dispatch(useApiQueryActions.success({id, paramsId, data}))
         } catch (error) {

--- a/src/react/use-api-query/index.tsx
+++ b/src/react/use-api-query/index.tsx
@@ -5,7 +5,7 @@ import {getParamsId} from '../../api/lib'
 import {
   ApiRequestFetchPolicy,
   ApiRequestMethod,
-  IApiRequestParams,
+  ApiRequestParams,
   ResponseBody
 } from '../../api/typings'
 import {ApiContext} from '../context'
@@ -57,7 +57,7 @@ export interface UseApiQueryActions<TResponseBody extends ResponseBody> {
  * instance of the response data
  */
 export function useApiQuery<TResponseBody extends ResponseBody>(
-  params: IApiRequestParams<ApiRequestMethod, TResponseBody> | null,
+  params: ApiRequestParams<ApiRequestMethod, TResponseBody> | null,
   opts: {
     fetchPolicy?: ApiRequestFetchPolicy
     deduplicate?: boolean

--- a/src/react/use-api-query/reducer.spec.tsx
+++ b/src/react/use-api-query/reducer.spec.tsx
@@ -1,5 +1,5 @@
 import {getParamsId} from '../../api/lib'
-import {IApiRequestParams} from '../../api/typings'
+import {ApiRequestParams} from '../../api/typings'
 import {useApiQueryActions} from './actions'
 import {useApiQueryReducer} from './reducer'
 
@@ -27,7 +27,7 @@ it('stores a successful response data if it matches the most recent request', ()
     {type: '@@INIT', payload: null} as any
   )
 
-  const params: IApiRequestParams = {
+  const params: ApiRequestParams = {
     method: 'GET',
     url: '/endpoint'
   }
@@ -115,7 +115,7 @@ it('only starts a refetch request if the request params are correct', () => {
   )
 
   const id = Symbol()
-  const params: IApiRequestParams = {
+  const params: ApiRequestParams = {
     method: 'GET',
     url: '/endpoint'
   }

--- a/src/react/use-api.tsx
+++ b/src/react/use-api.tsx
@@ -4,5 +4,5 @@ import {Api} from '../api'
 import {ApiContext} from './context'
 
 export function useApi(): Api {
-  return useContext(ApiContext)
+  return useContext(ApiContext).api
 }


### PR DESCRIPTION
## Summary of Changes

**Default fetch policy** (resolves #13)
* Default `Api#defaultFetchPolicy` to `'fetch-first'`, which affects calls to `Api#request` directly
* Default `useApiQuery`'s `fetchPolicy` to `'cache-and-fetch'` (encourages the [`stale-while-revalidate`](https://web.dev/stale-while-revalidate/) pattern which used by lots of data fetching libraries such as `react-query` and `swr`, as well as `apollo-client` by default)
  * Overridable via `ApiProvider#defaultFetchPolicy`

**`deduplicate` flag** (resolves #14)
* Add `deduplicate` flag which can be passed to `Api#request` and `useApiQuery` By default, this is `true` for `GET` requests and `false` for non-`GET` requests, but
* Update `RequestManager` to allow deduplicating requests for non-`GET` requests
* Remove `forceNewFetch` (since this `deduplicate` the same thing with support for non-`GET` requests)

**`extraKey` flag and removal of `useApiQuery#refetchOn`** (resolves #15)

After some thought, I don't like the `refetchOn: any[]` pattern for `useApiQuery`:
* It was unclear if it should have the same `fetchPolicy` functionality as calling `refetch` directly (always fetching over the network). 
* It doesn't solve the problem where we may want to store separately-cached responses for multiple versions of `POST` requests

To solve both of the above issues, I decided to add an `extraKey: string` flag to `RequestParams`. This allows the user to provide an arbitrary additional key which is serialized into the cache key. This can be set via any `HttpEndpoints` method, such as `HttpEndpoints._get`. This should provide enough flexibility to satisfy a variety of caching/refetching use cases.

**Allow cache reads for non-`GET` requests**
This is necessary in combination with the addition of `RequestParams#extraKey` in order to support caching non-`GET` requests.